### PR TITLE
Upgrade runtime to node 16 and bump version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
 
       - name: "Enforce Version"
         id: enforce
-        uses: sharesight/enforce-package-dependency-version@v1.1.3
+        uses: sharesight/enforce-package-dependency-version@v2
         with:
           package: "typescript"
           range: ">=4.2.0"

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: yellow
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 
 inputs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enforce-package-dependency-version",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Allows us to enforce a specific package dependency version in a `package.json` file.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Address Node runtime deprecation by GitHub (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).